### PR TITLE
FEAT: go handler for carbon check

### DIFF
--- a/controllers/carbon.go
+++ b/controllers/carbon.go
@@ -1,30 +1,58 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
+type CarbonData struct {
+	Statistics struct {
+		AdjustedBytes float64 `json:"adjustedBytes"`
+		Energy        float64 `json:"energy"`
+		Co2           struct {
+			Grid struct {
+				Grams  float64 `json:"grams"`
+				Litres float64 `json:"litres"`
+			} `json:"grid"`
+			Renewable struct {
+				Grams  float64 `json:"grams"`
+				Litres float64 `json:"litres"`
+			} `json:"renewable"`
+		} `json:"co2"`
+	} `json:"statistics"`
+	CleanerThan int    `json:"cleanerThan"`
+	ScanUrl     string `json:"scanUrl"`
+}
+
 type CarbonController struct{}
 
 // Function to get the HTML size of the website
-func getHtmlSize(url string) (int, error) {
+func getHtmlSize(ctx context.Context, url string) (int, error) {
 	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
 		url = "http://" + url
 	}
-
-	resp, err := http.Get(url)
+	client := &http.Client{
+		Timeout: time.Second * 5,
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get HTML size: %w", err)
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -33,26 +61,39 @@ func getHtmlSize(url string) (int, error) {
 }
 
 // Function to get the carbon data based on the HTML size
-func getCarbonData(sizeInBytes int) (map[string]interface{}, error) {
-	apiUrl := fmt.Sprintf("https://api.websitecarbon.com/data?bytes=%d&green=0", sizeInBytes)
+func getCarbonData(ctx context.Context, sizeInBytes int) (*CarbonData, error) {
+	const carbonDataUrl = "https://api.websitecarbon.com/data"
 
-	resp, err := http.Get(apiUrl)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, carbonDataUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	q := req.URL.Query()
+	q.Add("bytes", strconv.Itoa(sizeInBytes))
+	q.Add("green", "0")
+	req.URL.RawQuery = q.Encode()
+
+	client := http.Client{
+		Timeout: time.Second * 5,
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get carbon data: %w", err)
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	var carbonData map[string]interface{}
+	var carbonData CarbonData
 	if err := json.Unmarshal(body, &carbonData); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal carbon data: %w", err)
 	}
 
-	return carbonData, nil
+	return &carbonData, nil
 }
 
 // Handler for the /carbon endpoint
@@ -63,29 +104,61 @@ func (ctrl *CarbonController) CarbonHandler(c *gin.Context) {
 		return
 	}
 
-	sizeInBytes, err := getHtmlSize(url)
+	sizeInBytes, err := getHtmlSize(c.Request.Context(), url)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Error getting HTML size: %v", err)})
 		return
 	}
 
-	carbonData, err := getCarbonData(sizeInBytes)
+	carbonData, err := getCarbonData(c.Request.Context(), sizeInBytes)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Error getting carbon data: %v", err)})
 		return
 	}
 
-	if stats, ok := carbonData["statistics"].(map[string]interface{}); ok {
-		if adjustedBytes, ok := stats["adjustedBytes"].(float64); ok && adjustedBytes == 0 {
-			c.JSON(http.StatusOK, gin.H{"skipped": "Not enough info to get carbon data"})
-			return
-		}
-		if energy, ok := stats["energy"].(float64); ok && energy == 0 {
-			c.JSON(http.StatusOK, gin.H{"skipped": "Not enough info to get carbon data"})
-			return
-		}
+	if carbonData.Statistics.AdjustedBytes == 0 {
+		c.JSON(http.StatusOK, gin.H{"skipped": "Not enough info to get carbon data"})
+		return
+	}
+	if carbonData.Statistics.Energy == 0 {
+		c.JSON(http.StatusOK, gin.H{"skipped": "Not enough info to get carbon data"})
+		return
 	}
 
-	carbonData["scanUrl"] = url
+	carbonData.ScanUrl = url
 	c.JSON(http.StatusOK, carbonData)
+}
+
+func HandleCarbon() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		url := r.URL.Query().Get("url")
+		if url == "" {
+			JSONError(w, "Missing 'url' query parameter", http.StatusBadRequest)
+			return
+		}
+
+		sizeInBytes, err := getHtmlSize(r.Context(), url)
+		if err != nil {
+			JSONError(w, fmt.Sprintf("Error getting HTML size: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		carbonData, err := getCarbonData(r.Context(), sizeInBytes)
+		if err != nil {
+			JSONError(w, fmt.Sprintf("Error getting carbon data: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		if carbonData.Statistics.AdjustedBytes == 0 {
+			JSON(w, KV{"skipped": "Not enough info to get carbon data"}, http.StatusOK)
+			return
+		}
+		if carbonData.Statistics.Energy == 0 {
+			JSON(w, KV{"skipped": "Not enough info to get carbon data"}, http.StatusOK)
+			return
+		}
+
+		carbonData.ScanUrl = url
+		JSON(w, carbonData, http.StatusOK)
+	})
 }

--- a/controllers/carbon_test.go
+++ b/controllers/carbon_test.go
@@ -58,3 +58,40 @@ func TestCarbonHandler(t *testing.T) {
 	assert.Equal(t, float64(htmlSize), stats["adjustedBytes"], "Expected adjustedBytes to be %d, but got %v", htmlSize, stats["adjustedBytes"])
 	assert.Equal(t, 0.005, stats["energy"], "Expected energy to be 0.005, but got %v", stats["energy"])
 }
+
+func TestHandleCarbon(t *testing.T) {
+	t.Parallel()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "http://test.com",
+		httpmock.NewStringResponder(200, "<html><body>Test</body></html>"))
+
+	htmlSize := len("<html><body>Test</body></html>")
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://api.websitecarbon.com/data?bytes=%d&green=0", htmlSize),
+		httpmock.NewJsonResponderOrPanic(200, map[string]interface{}{
+			"statistics": map[string]interface{}{
+				"adjustedBytes": float64(htmlSize),
+				"energy":        0.005,
+			},
+		}))
+
+	req := httptest.NewRequest(http.MethodGet, "/carbon?url=http://test.com", nil)
+	rec := httptest.NewRecorder()
+	controllers.HandleCarbon().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "Expected status code 200, but got %d", rec.Code)
+
+	var data controllers.CarbonData
+	err := json.Unmarshal(rec.Body.Bytes(), &data)
+	assert.NoError(t, err, "Error unmarshaling response body")
+
+	assert.NotEmpty(t, data.ScanUrl, "scanUrl should not be nil")
+	assert.Equal(t, "http://test.com", data.ScanUrl, "Expected scanUrl to be 'http://test.com', but got %v", data.ScanUrl)
+
+	assert.NotEmpty(t, data.Statistics, "statistics should not be nil")
+	stats := data.Statistics
+	assert.Equal(t, float64(htmlSize), stats.AdjustedBytes, "Expected adjustedBytes to be %d, but got %v", htmlSize, stats.AdjustedBytes)
+	assert.Equal(t, 0.005, stats.Energy, "Expected energy to be 0.005, but got %v", stats.Energy)
+}

--- a/controllers/response.go
+++ b/controllers/response.go
@@ -16,3 +16,11 @@ func JSONError(w http.ResponseWriter, err string, code int) {
 		Error: err,
 	})
 }
+
+type KV map[string]any
+
+func JSON(w http.ResponseWriter, v any, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(v)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module web-check-go
 
-go 1.21.3
+go 1.22.4
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20240602235142-49d0e97b7881


### PR DESCRIPTION
- Add go handler for carbon check
- Type the carbon response
- Remove deprecated module usage
- Pass context and bound child http calls
- update to latest go for security fixes