### PR TITLE
FEAT: add a net/http server

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
+HOST=localhost
+PORT=8080
 DEBUG=True
 ALLOWED_HOSTS=localhost

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+HOST=localhost
+PORT=8080

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+$(shell cp -n .env.example .env)
+include .env
+export
+
 run:
 	@go run main.go
 .PHONY: run

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"cmp"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type Config struct {
+	Host           string
+	Port           string
+	AllowedOrigins []string
+}
+
+func New() Config {
+	host := getEnvDefault("HOST", "0.0.0.0")
+	port := getEnvDefault("PORT", "8080")
+	return Config{
+		Host: host,
+		Port: port,
+		AllowedOrigins: strings.Split(
+			getEnvDefault("ALLOWED_ORIGINS", fmt.Sprintf("http://%s:%s,https://%s:%s", host, port, host, port)), ",",
+		),
+	}
+}
+
+func getEnvDefault(key, def string) string {
+	return cmp.Or(os.Getenv(key), def)
+}

--- a/handlers/response.go
+++ b/handlers/response.go
@@ -28,3 +28,18 @@ func JSON(w http.ResponseWriter, v any, code int) {
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(v)
 }
+
+func NotFound(h http.Handler) http.Handler {
+	type Response struct {
+		Status string `json:"status"`
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if h == nil || r.URL.Path != "/" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(Response{Status: "route not found"})
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/xray-web/web-check-api/config"
+	"github.com/xray-web/web-check-api/handlers"
+)
+
+type Server struct {
+	conf config.Config
+	mux  *http.ServeMux
+}
+
+func New(conf config.Config) *Server {
+	return &Server{
+		conf: conf,
+		mux:  http.NewServeMux(),
+	}
+}
+
+func (s *Server) routes() {
+	s.mux.Handle("/", handlers.NotFound(nil))
+
+	s.mux.Handle("GET /headers", handlers.HandleGetHeaders())
+	s.mux.Handle("GET /cookies", handlers.HandleCookies())
+	s.mux.Handle("GET /carbon", handlers.HandleCarbon())
+	s.mux.Handle("GET /block-lists", handlers.HandleBlockLists())
+	s.mux.Handle("GET /dns-server", handlers.HandleDNSServer())
+	s.mux.Handle("GET /dns", handlers.HandleDNS())
+	s.mux.Handle("GET /dnssec", handlers.HandleDnsSec())
+	s.mux.Handle("GET /firewall", handlers.HandleFirewall())
+	s.mux.Handle("GET /get-ip", handlers.HandleGetIP())
+	s.mux.Handle("GET /hsts", handlers.HandleHsts())
+	s.mux.Handle("GET /http-security", handlers.HandleHttpSecurity())
+	s.mux.Handle("GET /legacy-rank", handlers.HandleLegacyRank())
+	s.mux.Handle("GET /linked-pages", handlers.HandleGetLinks())
+	s.mux.Handle("GET /ports", handlers.HandleGetPorts())
+	s.mux.Handle("GET /quality", handlers.HandleGetQuality())
+	s.mux.Handle("GET /rank", handlers.HandleGetRank())
+	s.mux.Handle("GET /redirects", handlers.HandleGetRedirects())
+	s.mux.Handle("GET /social-tags", handlers.HandleGetSocialTags())
+	s.mux.Handle("GET /tls", handlers.HandleTLS())
+	s.mux.Handle("GET /trace-route", handlers.HandleTraceRoute())
+}
+
+func (s *Server) Run() error {
+	s.routes()
+
+	addr := fmt.Sprintf("%s:%s", s.conf.Host, s.conf.Port)
+	log.Printf("Server started, listening on: %v\n", addr)
+	return http.ListenAndServe(addr, s.mux)
+}


### PR DESCRIPTION
- Add a server using default `net/http`
- Add custom NotFound handler
- Add independent server config
- Manage .env files with makefile