### PR TITLE
FIX: disable parallel tests that use mocks

### DIFF
--- a/handlers/carbon_test.go
+++ b/handlers/carbon_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestHandleCarbon(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 

--- a/handlers/rank_test.go
+++ b/handlers/rank_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestHandleGetRank(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 	tests := []struct {
 		name           string
 		urlParam       string

--- a/handlers/social_tags_test.go
+++ b/handlers/social_tags_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestHandleGetSocialTags(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 	tests := []struct {
 		name           string
 		urlParam       string
@@ -64,7 +64,7 @@ func TestHandleGetSocialTags(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 			defer gock.Off()
 
 			if tc.urlParam != "" {

--- a/handlers/tls_test.go
+++ b/handlers/tls_test.go
@@ -51,7 +51,7 @@ func TestHandleTLS(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 			defer gock.Off()
 
 			if tc.urlParam != "" {


### PR DESCRIPTION
- the go mocking libs are not suitable to be used for parallel tests in their current state.