### PR TITLE
Feat/healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,18 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /app/bin/app main.go
 
 # Stage 2: Run the application
-# Create non-root user, copy bin from build stage, set perms, expose port, run app
-FROM alpine:latest
+# Create non-root user, copy bin from build stage, set perms,
+# expose port, start health check and then run the app
+FROM alpine:3.20
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 COPY --from=builder /app/bin/app /usr/local/bin/app
 RUN chmod +x /usr/local/bin/app
 USER appuser
 EXPOSE 8080
+HEALTHCHECK \
+  --interval=30s \
+  --timeout=10s \
+  --start-period=5s \
+  --retries=3 \
+  CMD curl -f http://localhost:8080/health || exit 1
 CMD ["app"]
-

--- a/handlers/health-check.go
+++ b/handlers/health-check.go
@@ -1,0 +1,14 @@
+package handlers
+
+import (
+	"net/http"
+)
+
+// HandleHealthCheck returns the status of the application
+func HandleHealthCheck() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok", "message":"We're alive!"}`))
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -44,6 +44,7 @@ func (s *Server) routes() {
 	s.mux.Handle("GET /api/social-tags", handlers.HandleGetSocialTags())
 	s.mux.Handle("GET /api/tls", handlers.HandleTLS())
 	s.mux.Handle("GET /api/trace-route", handlers.HandleTraceRoute())
+	s.mux.Handle("GET /health", handlers.HandleHealthCheck())
 }
 
 func (s *Server) Run() error {


### PR DESCRIPTION
Adds a healthcheck endpoint, and implements it into the Dockerfile.
This will be needed for a blue-green style re-deployment so that there's always at least 1 container running in prod.