### PR TITLE
CI/bin releases worlfow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: 🐳 Build + Publish Multi-Platform Image
+name: 🐳 Publish Docker
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
             goos: darwin
           - goarch: arm64
             goos: windows
-    steps:
+      steps:
       - name: Checkout code 🛎️
         uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,35 +60,34 @@ jobs:
             goos: darwin
           - goarch: arm64
             goos: windows
-      steps:
-      - name: Checkout code 🛎️
-        uses: actions/checkout@v3
+    steps:
+    - name: Checkout code 🛎️
+      uses: actions/checkout@v3
 
-      - name: Set up Go 🏗️
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.22.4
+    - name: Set up Go 🏗️
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.22.4
 
-      - name: Compile Go binaries 🔨
-        run: |
-          go build -ldflags "-X main.Version=${{ needs.create-draft-release.outputs.tag_name }}" -o web-check-api .
+    - name: Compile Go binaries 🔨
+      run: |
+        go build -ldflags "-X main.Version=${{ needs.create-draft-release.outputs.tag_name }}" -o web-check-api .
       env:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
         GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+    - name: Upload Go binaries ⤴️
+      uses: actions/upload-artifact@v2
+      with:
+        name: web-check-api-${{ matrix.goos }}-${{ matrix.goarch }}
+        path: web-check-api
 
-      - name: Upload Go binaries ⤴️
-        uses: actions/upload-artifact@v2
-        with:
-          name: web-check-api-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: web-check-api
-
-      - name: Attach binaries to release 📎
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ needs.create-draft-release.outputs.release_id }}
-          asset_path: web-check-api
-          asset_name: web-check-api-${{ matrix.goos }}-${{ matrix.goarch }}
-          asset_content_type: application/octet-stream
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+    - name: Attach binaries to release 📎
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ needs.create-draft-release.outputs.release_id }}
+        asset_path: web-check-api
+        asset_name: web-check-api-${{ matrix.goos }}-${{ matrix.goarch }}
+        asset_content_type: application/octet-stream
+      env:
+        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,55 @@
-name: 🛠️ Compile Release Assets
+# Upon a new tag being pushed to git, this workflow will:
+# - Get the app version (from tag)
+# - Draft a new release with release notes
+# - Compile the Go binary for all platforms
+# - Attach the compiled binaries to the release
+name: 🏗️ Release Binaries
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - '^[0-9]+\.[0-9]+\.[0-9]+$'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to draft a release for (must already exist)'
+        required: true
 
 jobs:
-  releases-matrix:
-    name: Release Go Binary
+  create-draft-release:
+    name: Create Draft Release 1️⃣
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create_release.outputs.id }}
+      tag_name: ${{ steps.get_tag_name.outputs.tag_name }}
+    steps:
+      - name: Checkout code 🛎️
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get Tag Name 🏷️
+        id: get_tag_name
+        run: echo "::set-output name=tag_name::${GITHUB_REF##*/}"
+
+      - name: Create Draft Release 📝
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          release_name: Release ${{ github.event.inputs.tag || github.ref_name }}
+          draft: true
+          prerelease: false
+          generate_release_notes: true
+
+      - name: Output new release URL ↗️
+        run: 'echo "Draft release URL: ${{ steps.create_release.outputs.html_url }}"'
+
+  compile-and-attach:
+    name: Compile and Attach Go Binary 2️⃣
+    needs: create-draft-release
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,15 +61,34 @@ jobs:
           - goarch: arm64
             goos: windows
     steps:
-    - name: Checkout code 🛎️
-      uses: actions/checkout@v3
-    - name: Compile Go binaries 🏗️
-      uses: wangyoucao577/go-release-action@v1.29
-      with:
-        github_token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        goversion: 1.22.4
-        project_path: '.'
-        binary_name: web-check-api
-        md5sum: true
+      - name: Checkout code 🛎️
+        uses: actions/checkout@v3
+
+      - name: Set up Go 🏗️
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.22.4
+
+      - name: Compile Go binaries 🔨
+        run: |
+          go build -ldflags "-X main.Version=${{ needs.create-draft-release.outputs.tag_name }}" -o web-check-api .
+      env:
+        GOOS: ${{ matrix.goos }}
+        GOARCH: ${{ matrix.goarch }}
+        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Upload Go binaries ⤴️
+        uses: actions/upload-artifact@v2
+        with:
+          name: web-check-api-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: web-check-api
+
+      - name: Attach binaries to release 📎
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ needs.create-draft-release.outputs.release_id }}
+          asset_path: web-check-api
+          asset_name: web-check-api-${{ matrix.goos }}-${{ matrix.goarch }}
+          asset_content_type: application/octet-stream
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds workflow to run whenever new tag created. Drafts new release with release notes, builds binary passing app version (from tag) in, then attatches the built executables to github release and publishes.
