### PR TITLE
FEAT: update allow origin from vars, limit methods

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 HOST=localhost
 PORT=8080
+ALLOWED_ORIGINS=http://localhost:8080

--- a/config/config.go
+++ b/config/config.go
@@ -4,24 +4,21 @@ import (
 	"cmp"
 	"fmt"
 	"os"
-	"strings"
 )
 
 type Config struct {
-	Host           string
-	Port           string
-	AllowedOrigins []string
+	Host          string
+	Port          string
+	AllowedOrigin string
 }
 
 func New() Config {
 	host := getEnvDefault("HOST", "0.0.0.0")
 	port := getEnvDefault("PORT", "8080")
 	return Config{
-		Host: host,
-		Port: port,
-		AllowedOrigins: strings.Split(
-			getEnvDefault("ALLOWED_ORIGINS", fmt.Sprintf("http://%s:%s,https://%s:%s", host, port, host, port)), ",",
-		),
+		Host:          host,
+		Port:          port,
+		AllowedOrigin: getEnvDefault("ALLOWED_ORIGINS", fmt.Sprintf("http://%s:%s", host, port)),
 	}
 }
 

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -5,13 +5,12 @@ import (
 	"net/http"
 )
 
-func CORS(h http.Handler) http.Handler {
+func (s *Server) CORS(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// TODO: determine allowed origins
-		w.Header().Set("Access-Control-Allow-Origin", "http://artwork.local:3000")
+		w.Header().Set("Access-Control-Allow-Origin", s.conf.AllowedOrigin)
 		w.Header().Set("Access-Control-Max-Age", "86400")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE, UPDATE")
-		w.Header().Set("Access-Control-Allow-Headers", "Origin, Content-Type, api_key, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Origin, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 		w.Header().Set("Access-Control-Expose-Headers", "Content-Length")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Cache-Control", "no-cache")

--- a/server/server.go
+++ b/server/server.go
@@ -52,5 +52,5 @@ func (s *Server) Run() error {
 
 	addr := fmt.Sprintf("%s:%s", s.conf.Host, s.conf.Port)
 	log.Printf("Server started, listening on: %v\n", addr)
-	return http.ListenAndServe(addr, CORS(s.mux))
+	return http.ListenAndServe(addr, s.CORS(s.mux))
 }


### PR DESCRIPTION
- Limit CORS Methods to whats actually available.
- Pass through allowed origins from env