### PR TITLE
CI: update test workflow deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,31 +12,29 @@ on:
 
 jobs:
   test:
+    name: 🧪 Test
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code 🛎️
-      uses: actions/checkout@v2
+      - name: Checkout code 🛎️
+        uses: actions/checkout@v4
 
-    - name: Set up Go 🧰
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.22.4
+      - name: Set up Go 🧰
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-    - name: Install dependencies ⏬
-      run: go mod tidy
+      - name: Run tests 🛠️
+        run: make test
 
-    - name: Run tests 🛠️
-      run: make test
+      - name: Report coverage 📈
+        run: go test -coverprofile=coverage.out ./...
 
-    - name: Report coverage 📈
-      run: go test -coverprofile=coverage.out ./...
-    
-    - name: Upload coverage to Codecov 📤
-      uses: codecov/codecov-action@v2
-      with:
-        files: coverage.out
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage to Codecov 📤
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.out
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Update actions to latest versions
- Use go.mod as source for go version
- Dont run go mod tidy as that would update the deps