### PR TITLE
RF: linked pages

### DIFF
--- a/checks/checks.go
+++ b/checks/checks.go
@@ -8,11 +8,12 @@ import (
 )
 
 type Checks struct {
-	Carbon     *Carbon
-	LegacyRank *LegacyRank
-	Rank       *Rank
-	SocialTags *SocialTags
-	Tls        *Tls
+	Carbon      *Carbon
+	LegacyRank  *LegacyRank
+	LinkedPages *LinkedPages
+	Rank        *Rank
+	SocialTags  *SocialTags
+	Tls         *Tls
 }
 
 func NewChecks() *Checks {
@@ -20,10 +21,11 @@ func NewChecks() *Checks {
 		Timeout: 5 * time.Second,
 	}
 	return &Checks{
-		Carbon:     NewCarbon(client),
-		LegacyRank: NewLegacyRank(legacyrank.NewInMemoryStore()),
-		Rank:       NewRank(client),
-		SocialTags: NewSocialTags(client),
-		Tls:        NewTls(client),
+		Carbon:      NewCarbon(client),
+		LegacyRank:  NewLegacyRank(legacyrank.NewInMemoryStore()),
+		LinkedPages: NewLinkedPages(client),
+		Rank:        NewRank(client),
+		SocialTags:  NewSocialTags(client),
+		Tls:         NewTls(client),
 	}
 }

--- a/checks/linked_pages.go
+++ b/checks/linked_pages.go
@@ -1,0 +1,120 @@
+package checks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+type LinkedPagesData struct {
+	Internal []string `json:"internal"`
+	External []string `json:"external"`
+}
+
+type LinkedPages struct {
+	client *http.Client
+}
+
+func NewLinkedPages(client *http.Client) *LinkedPages {
+	return &LinkedPages{client: client}
+}
+
+func (l *LinkedPages) GetLinkedPages(ctx context.Context, targetURL *url.URL) (LinkedPagesData, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL.String(), nil)
+	if err != nil {
+		return LinkedPagesData{}, err
+	}
+
+	resp, err := l.client.Do(req)
+	if err != nil {
+		return LinkedPagesData{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return LinkedPagesData{}, fmt.Errorf("received non-200 response code")
+	}
+
+	doc, err := html.Parse(resp.Body)
+	if err != nil {
+		return LinkedPagesData{}, err
+	}
+
+	internalLinksMap := make(map[string]int)
+	externalLinksMap := make(map[string]int)
+	walkDom(doc, targetURL, internalLinksMap, externalLinksMap)
+
+	return LinkedPagesData{
+		Internal: sortURLsByFrequency(internalLinksMap),
+		External: sortURLsByFrequency(externalLinksMap),
+	}, nil
+}
+
+func walkDom(n *html.Node, parsedTargetURL *url.URL, internalLinksMap map[string]int, externalLinksMap map[string]int) {
+	if n.Type == html.ElementNode && n.Data == "a" {
+		for _, attr := range n.Attr {
+			if attr.Key == "href" {
+				href := attr.Val
+				absoluteURL, err := resolveURL(parsedTargetURL, href)
+				if err != nil {
+					continue
+				}
+				if strings.TrimPrefix(absoluteURL.Hostname(), "www.") == parsedTargetURL.Hostname() {
+					internalLinksMap[absoluteURL.String()]++
+				} else if absoluteURL.Scheme == "http" || absoluteURL.Scheme == "https" {
+					externalLinksMap[absoluteURL.String()]++
+				}
+				break
+			}
+		}
+	}
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		walkDom(child, parsedTargetURL, internalLinksMap, externalLinksMap)
+	}
+}
+
+// NOTE: This function resolves a href based on how it would be interpreted by the browser, and does NOT check for typos or whether the URL is reachable.
+// Only hrefs containing a scheme or beginning with "//" (denoting a relative scheme) will be resolved as absolute URLs.
+// E.g. A href of "http//example.com" will resolve against a base url of "http://example.com" as "http://example.com/http//example.com" since this is how the browser will interpret it
+func resolveURL(baseURL *url.URL, href string) (*url.URL, error) {
+	u, err := url.Parse(href)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme == "" {
+		return baseURL.ResolveReference(u), nil
+	}
+	return u, nil
+}
+
+func sortURLsByFrequency(linksMap map[string]int) []string {
+	type link struct {
+		URL       string
+		Frequency int
+	}
+
+	var links []link
+	for k, v := range linksMap {
+		links = append(links, link{k, v})
+	}
+
+	sort.SliceStable(links, func(i, j int) bool {
+		return links[i].URL < links[j].URL
+	})
+
+	sort.SliceStable(links, func(i, j int) bool {
+		return links[i].Frequency > links[j].Frequency
+	})
+
+	var sortedLinks []string
+	for _, link := range links {
+		sortedLinks = append(sortedLinks, link.URL)
+	}
+
+	return sortedLinks
+}

--- a/checks/linked_pages_test.go
+++ b/checks/linked_pages_test.go
@@ -1,0 +1,146 @@
+package checks
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xray-web/web-check-api/testutils"
+)
+
+func TestGetLinkedPages(t *testing.T) {
+	t.Parallel()
+	testTargetURL := &url.URL{
+		Scheme: "http",
+		Host:   "internal.com",
+	}
+	testHTML := []byte(`
+		<a href="http://internal.com/#heading"></a>
+		<a href="//internal.com/1"></a>
+		<a href="2"></a>
+		<a href="/2"></a>
+		<a href="http://external.com/1"></a>
+		<a href="https://external.com/2"></a>
+		<a href="http://external.com/2"></a>
+		<a href="://external.com"></a>
+		`)
+	client := testutils.MockClient(testutils.Response(http.StatusOK, testHTML))
+	actualLinkedPagesData, err := NewLinkedPages(client).GetLinkedPages(context.TODO(), testTargetURL)
+	assert.NoError(t, err)
+	assert.Equal(t, LinkedPagesData{
+		Internal: []string{
+			"http://internal.com/2",
+			"http://internal.com/#heading",
+			"http://internal.com/1",
+		},
+		External: []string{
+			"http://external.com/1",
+			"http://external.com/2",
+			"https://external.com/2",
+		},
+	}, actualLinkedPagesData)
+}
+
+func TestResolveURL(t *testing.T) {
+	t.Parallel()
+	baseURL := url.URL{
+		Scheme: "http",
+		Host:   "example.com",
+	}
+
+	tests := []struct {
+		name                string
+		href                string
+		expectedResolvedURL (*url.URL)
+		expectedErrorExists bool
+	}{
+		{
+			name:                "empty href",
+			href:                "",
+			expectedResolvedURL: &url.URL{Scheme: "http", Host: "example.com"},
+			expectedErrorExists: false,
+		},
+		{
+			name:                "missing scheme",
+			href:                "://example.com",
+			expectedResolvedURL: nil,
+			expectedErrorExists: true,
+		},
+		{
+			name:                "relative scheme",
+			href:                "//example.com",
+			expectedResolvedURL: &url.URL{Scheme: "http", Host: "example.com"},
+			expectedErrorExists: false,
+		},
+		{
+			name:                "valid absolute url without path",
+			href:                "http://example.com",
+			expectedResolvedURL: &url.URL{Scheme: "http", Host: "example.com"},
+			expectedErrorExists: false,
+		},
+		{
+			name:                "valid absolute url with path",
+			href:                "http://example.com/123",
+			expectedResolvedURL: &url.URL{Scheme: "http", Host: "example.com", Path: "/123"},
+			expectedErrorExists: false,
+		},
+		{
+			name:                "valid relative url with leading slash",
+			href:                "/123",
+			expectedResolvedURL: &url.URL{Scheme: "http", Host: "example.com", Path: "/123"},
+			expectedErrorExists: false,
+		},
+		{
+			name:                "valid relative url without leading slash",
+			href:                "123",
+			expectedResolvedURL: &url.URL{Scheme: "http", Host: "example.com", Path: "/123"},
+			expectedErrorExists: false,
+		},
+		{
+			name:                "valid relative url edge case",
+			href:                "http//example.com",
+			expectedResolvedURL: &url.URL{Scheme: "http", Host: "example.com", Path: "/http//example.com"},
+			expectedErrorExists: false,
+		},
+		{
+			name:                "valid relative url fragment",
+			href:                "#heading",
+			expectedResolvedURL: &url.URL{Scheme: "http", Host: "example.com", Fragment: "heading"},
+			expectedErrorExists: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actualResolvedURL, err := resolveURL(&baseURL, tc.href)
+			assert.Equal(t, tc.expectedResolvedURL, actualResolvedURL)
+			if tc.expectedErrorExists {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSortURLsByFrequency(t *testing.T) {
+	t.Parallel()
+	testLinksMap := map[string]int{
+		"https://example.com":  1,
+		"https://example2.com": 2,
+		"https://example3.com": 3,
+	}
+
+	expectedSortedLinks := []string{
+		"https://example3.com",
+		"https://example2.com",
+		"https://example.com",
+	}
+
+	actualSortedLinks := sortURLsByFrequency(testLinksMap)
+	assert.Equal(t, expectedSortedLinks, actualSortedLinks)
+}

--- a/handlers/linked_pages.go
+++ b/handlers/linked_pages.go
@@ -1,121 +1,13 @@
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-	"sort"
-	"strings"
 
-	"golang.org/x/net/html"
+	"github.com/xray-web/web-check-api/checks"
 )
 
-type LinkResponse struct {
-	Internal []string `json:"internal"`
-	External []string `json:"external"`
-}
-
-type ErrorResponse struct {
-	Skipped string `json:"skipped"`
-}
-
-func (e ErrorResponse) Error() string {
-	b, _ := json.Marshal(e)
-	return string(b)
-}
-
-func getLinks(targetURL string) ([]string, []string, error) {
-	resp, err := http.Get(targetURL)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error making request: %s", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("received non-200 response code")
-	}
-
-	parsedURL, err := url.Parse(targetURL)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing URL: %s", err)
-	}
-
-	doc, err := html.Parse(resp.Body)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing HTML: %s", err)
-	}
-
-	internalLinksMap := make(map[string]int)
-	externalLinksMap := make(map[string]int)
-
-	var f func(*html.Node)
-	f = func(n *html.Node) {
-		if n.Type == html.ElementNode && n.Data == "a" {
-			for _, attr := range n.Attr {
-				if attr.Key == "href" {
-					href := attr.Val
-					absoluteURL := resolveURL(parsedURL, href)
-					if isInternalLink(absoluteURL, parsedURL) {
-						internalLinksMap[absoluteURL]++
-					} else if strings.HasPrefix(absoluteURL, "http://") || strings.HasPrefix(absoluteURL, "https://") {
-						externalLinksMap[absoluteURL]++
-					}
-				}
-			}
-		}
-		for child := n.FirstChild; child != nil; child = child.NextSibling {
-			f(child)
-		}
-	}
-	f(doc)
-
-	internalLinks := sortAndExtractKeys(internalLinksMap)
-	externalLinks := sortAndExtractKeys(externalLinksMap)
-
-	return internalLinks, externalLinks, nil
-}
-
-func resolveURL(baseURL *url.URL, href string) string {
-	u, err := url.Parse(href)
-	if err != nil || !u.IsAbs() {
-		return baseURL.ResolveReference(u).String()
-	}
-	return u.String()
-}
-
-func isInternalLink(link string, baseURL *url.URL) bool {
-	parsedLink, err := url.Parse(link)
-	if err != nil {
-		return false
-	}
-	return parsedLink.Hostname() == baseURL.Hostname()
-}
-
-func sortAndExtractKeys(m map[string]int) []string {
-	type kv struct {
-		Key   string
-		Value int
-	}
-
-	var ss []kv
-	for k, v := range m {
-		ss = append(ss, kv{k, v})
-	}
-
-	sort.Slice(ss, func(i, j int) bool {
-		return ss[i].Value > ss[j].Value
-	})
-
-	var sortedKeys []string
-	for _, kv := range ss {
-		sortedKeys = append(sortedKeys, kv.Key)
-	}
-
-	return sortedKeys
-}
-
-func HandleGetLinks() http.Handler {
+func HandleGetLinks(l *checks.LinkedPages) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rawURL, err := extractURL(r)
 		if err != nil {
@@ -123,25 +15,22 @@ func HandleGetLinks() http.Handler {
 			return
 		}
 
-		internalLinks, externalLinks, err := getLinks(rawURL.String())
+		links, err := l.GetLinkedPages(r.Context(), rawURL)
 		if err != nil {
-			JSONError(w, err, http.StatusInternalServerError)
+			JSONError(w, fmt.Errorf("error getting linked pages: %v", err), http.StatusInternalServerError)
 			return
 		}
 
-		if len(internalLinks) == 0 && len(externalLinks) == 0 {
-			JSONError(w, ErrorResponse{
-				Skipped: "No internal or external links found. " +
-					"This may be due to the website being dynamically rendered, using a client-side framework (like React), and without SSR enabled. " +
-					"That would mean that the static HTML returned from the HTTP request doesn't contain any meaningful content for Web-Check to analyze. " +
-					"You can rectify this by using a headless browser to render the page instead.",
-			}, http.StatusBadRequest)
+		if len(links.Internal) == 0 && len(links.External) == 0 {
+			JSON(w, KV{
+				"skipped": `No internal or external links found. 
+				This may be due to the website being dynamically rendered, using a client-side framework (like React), and without SSR enabled. 
+				That would mean that the static HTML returned from the HTTP request doesn't contain any meaningful content for Web-Check to analyze. 
+				You can rectify this by using a headless browser to render the page instead.`,
+			}, http.StatusOK)
 			return
 		}
 
-		JSON(w, LinkResponse{
-			Internal: internalLinks,
-			External: externalLinks,
-		}, http.StatusOK)
+		JSON(w, links, http.StatusOK)
 	})
 }

--- a/handlers/linked_pages_test.go
+++ b/handlers/linked_pages_test.go
@@ -7,21 +7,73 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xray-web/web-check-api/checks"
+	"github.com/xray-web/web-check-api/testutils"
 )
 
 func TestHandleGetLinks(t *testing.T) {
 	t.Parallel()
-	req := httptest.NewRequest("GET", "/get-links?url=www.google.com", nil)
-	rec := httptest.NewRecorder()
-	HandleGetLinks().ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusOK, rec.Code)
+	t.Run("missing URL parameter", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest("GET", "/legacy-rank?url=", nil)
+		rec := httptest.NewRecorder()
 
-	var response LinkResponse
-	err := json.Unmarshal(rec.Body.Bytes(), &response)
-	assert.NoError(t, err)
+		HandleGetLinks(nil).ServeHTTP(rec, req)
 
-	assert.NotNil(t, response)
-	assert.NotNil(t, response.Internal)
-	assert.NotNil(t, response.External)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.JSONEq(t, `{"error": "missing URL parameter"}`, rec.Body.String())
+	})
+
+	t.Run("failed to get page body", func(t *testing.T) {
+		t.Parallel()
+		client := testutils.MockClient(testutils.Response(http.StatusInternalServerError, nil))
+
+		req := httptest.NewRequest("GET", "/legacy-rank?url=http://test.com", nil)
+		rec := httptest.NewRecorder()
+		HandleGetLinks(checks.NewLinkedPages(client)).ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		var response KV
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Contains(t, response["error"], "error getting linked pages")
+	})
+
+	t.Run("no linked pages", func(t *testing.T) {
+		t.Parallel()
+
+		testHTML := []byte(`<html><body>Test</body></html>`)
+		client := testutils.MockClient(testutils.Response(http.StatusOK, testHTML))
+		req := httptest.NewRequest("GET", "/legacy-rank?url=http://test.com", nil)
+		rec := httptest.NewRecorder()
+
+		HandleGetLinks(checks.NewLinkedPages(client)).ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var response KV
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Contains(t, response["skipped"], "No internal or external links found")
+	})
+
+	t.Run("linked pages successfully found", func(t *testing.T) {
+		t.Parallel()
+
+		testHTML := []byte(`
+		<a href="http://test.com/"></a>
+		<a href="http://external.com/"></a>`)
+		client := testutils.MockClient(testutils.Response(http.StatusOK, testHTML))
+		req := httptest.NewRequest("GET", "/legacy-rank?url=http://test.com", nil)
+		rec := httptest.NewRecorder()
+
+		HandleGetLinks(checks.NewLinkedPages(client)).ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var response checks.LinkedPagesData
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.NotNil(t, response.Internal)
+		assert.NotNil(t, response.External)
+	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -41,7 +41,7 @@ func (s *Server) routes() {
 	s.mux.Handle("GET /api/hsts", handlers.HandleHsts())
 	s.mux.Handle("GET /api/http-security", handlers.HandleHttpSecurity())
 	s.mux.Handle("GET /api/legacy-rank", handlers.HandleLegacyRank(s.checks.LegacyRank))
-	s.mux.Handle("GET /api/linked-pages", handlers.HandleGetLinks())
+	s.mux.Handle("GET /api/linked-pages", handlers.HandleGetLinks(s.checks.LinkedPages))
 	s.mux.Handle("GET /api/ports", handlers.HandleGetPorts())
 	s.mux.Handle("GET /api/quality", handlers.HandleGetQuality())
 	s.mux.Handle("GET /api/rank", handlers.HandleGetRank(s.checks.Rank))


### PR DESCRIPTION
- Moved linked pages to checks
- Added tests for logic-handling and for the linked pages handler. Tests use a mock client instead of making an actual GET request to avoid flakiness 
    - NOTE: The `resolveURL` function parses hrefs in the same way a browser would, which can lead to some unintuitive outcomes. I have left a comment by that function with further explanation and added some test cases for illustration 
- Modified the `sortURLsByFrequency` function to ensure that results are deterministic 
- Modified the `walkDom` function to ensure that "www" subdomains are disregarded when determining if a link is internal (previously, "www.google.com" would be considered an external link to "google.com", which seems like incorrect behaviour)
