### PR TITLE
FEAT: server graceful shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,13 +1,39 @@
 package main
 
 import (
+	"context"
 	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/xray-web/web-check-api/config"
 	"github.com/xray-web/web-check-api/server"
 )
 
 func main() {
-	s := server.New(config.New())
-	log.Println(s.Run())
+	srv := server.New(config.New())
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		if err := srv.Run(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("listen: %v\n", err)
+		}
+	}()
+
+	<-done
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer func() {
+		// extra handling here, databases etc
+		cancel()
+	}()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("Server Shutdown Failed:%+v", err)
+	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xray-web/web-check-api/config"
+	"golang.org/x/net/context"
+)
+
+func TestServer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("start server", func(t *testing.T) {
+		t.Parallel()
+
+		srv := New(config.New())
+		srv.routes()
+		ts := httptest.NewServer(srv.CORS(srv.mux))
+		defer ts.Close()
+
+		// wait up tot 10 seconds for health check to return 200
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(+10*time.Second))
+		defer cancel()
+		for {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/health", nil)
+			assert.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			if err == nil && resp.StatusCode == http.StatusOK {
+				break
+			}
+		}
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		err := srv.Shutdown(ctx)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
- Wait for active connections to finish before server shutdown
- Test server start up

This covers production scenarios where the server is actively serving requests when a shutdown signal is received, the server will wait up to 60 seconds for any active connections to finish while at the same time not accepting any new requests.

This means in production, clients and thus users wont experience abrupt call failures when we cycle containers