### PR TITLE
RF: add lookup interface to getIP

### DIFF
--- a/checks/checks.go
+++ b/checks/checks.go
@@ -12,7 +12,7 @@ type Checks struct {
 	BlockList   *BlockList
 	Carbon      *Carbon
 	Headers     *Headers
-	IpAddress   *Ip
+	IpAddress   *NetIp
 	LegacyRank  *LegacyRank
 	LinkedPages *LinkedPages
 	Rank        *Rank
@@ -28,7 +28,7 @@ func NewChecks() *Checks {
 		BlockList:   NewBlockList(&ip.NetDNSLookup{}),
 		Carbon:      NewCarbon(client),
 		Headers:     NewHeaders(client),
-		IpAddress:   NewIp(NewNetIp()),
+		IpAddress:   NewNetIp(&ip.NetLookup{}),
 		LegacyRank:  NewLegacyRank(legacyrank.NewInMemoryStore()),
 		LinkedPages: NewLinkedPages(client),
 		Rank:        NewRank(client),

--- a/checks/getIP_test.go
+++ b/checks/getIP_test.go
@@ -6,24 +6,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xray-web/web-check-api/checks/clients/ip"
 )
 
 func TestLookup(t *testing.T) {
 	t.Parallel()
 
-	ipAddresses := []IpAddress{
-		{net.ParseIP("216.58.201.110"), 4},
-		{net.ParseIP("2a00:1450:4009:826::200e"), 6},
-	}
-	i := NewIp(IpGetterFunc(func(ctx context.Context, host string) ([]IpAddress, error) {
-		return ipAddresses, nil
+	n := NewNetIp(ip.LookupFunc(func(ctx context.Context, network string, host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("216.58.201.110")}, nil
 	}))
-	actual, err := i.Lookup(context.Background(), "google.com")
+	actual, err := n.GetIp(context.Background(), "google.com")
 	assert.NoError(t, err)
 
-	assert.Equal(t, ipAddresses[0].Address, actual[0].Address)
-	assert.Equal(t, 4, actual[0].Family)
-
-	assert.Equal(t, ipAddresses[1].Address, actual[1].Address)
-	assert.Equal(t, 6, actual[1].Family)
+	assert.Contains(t, actual, IpAddress{Address: net.ParseIP("216.58.201.110"), Family: 4})
 }

--- a/handlers/getIP.go
+++ b/handlers/getIP.go
@@ -6,7 +6,7 @@ import (
 	"github.com/xray-web/web-check-api/checks"
 )
 
-func HandleGetIP(i *checks.Ip) http.Handler {
+func HandleGetIP(i *checks.NetIp) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rawURL, err := extractURL(r)
 		if err != nil {
@@ -14,7 +14,7 @@ func HandleGetIP(i *checks.Ip) http.Handler {
 			return
 		}
 
-		result, err := i.Lookup(r.Context(), rawURL.Hostname())
+		result, err := i.GetIp(r.Context(), rawURL.Hostname())
 		if err != nil {
 			JSONError(w, err, http.StatusInternalServerError)
 			return


### PR DESCRIPTION
- Refactored to utilise the `LookUp` interface implemented in `checks/client/ip`
- Fixed error handling where error is only returned if both IPV4 and IPV6 addresses are not present
